### PR TITLE
builds for STM32F4, template uses the GPIO_EXTI example

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,33 +15,35 @@
 # License	http://www.gnu.org/licenses/gpl.txt GNU Public License
 # Author	Steffen Vogel <post@steffenvogel.de>
 # Link		http://www.steffenvogel.de
-# 
+#
+# edited for the STM32F4-Discovery
 
 # A name common to all output files (elf, map, hex, bin, lst)
 TARGET     = demo
 
 # Take a look into $(CUBE_DIR)/Drivers/BSP for available BSPs
-BOARD      = STM32F3-Discovery
+BOARD      = STM32F4-Discovery
+BSP_BASE   = stm32f4_discovery
 
-OCDFLAGS   = -f board/stm32f3discovery.cfg
-GDBFLAGS   = 
+OCDFLAGS   = -f board/stm32f4discovery.cfg
+GDBFLAGS   =
 
 #EXAMPLE   = Templates
-EXAMPLE    = Examples/GPIO/GPIO_IOToggle
+EXAMPLE    = Examples/GPIO/GPIO_EXTI
 
 # MCU family and type in various capitalizations o_O
-MCU_FAMILY = stm32f3xx
-MCU_LC     = stm32f303xc
-MCU_MC     = STM32F303xC
-MCU_UC     = STM32F303XC
+MCU_FAMILY = stm32f4xx
+MCU_LC     = stm32f401xc
+MCU_MC     = STM32F407xx
+MCU_UC     = STM32F407VG
 
 # Your C files from the /src directory
 SRCS       = main.c
 SRCS      += system_$(MCU_FAMILY).c
-SRCS      += stm32f3xx_it.c
+SRCS      += stm32f4xx_it.c
 
 # Basic HAL libraries
-SRCS      += stm32f3xx_hal_rcc.c stm32f3xx_hal_rcc_ex.c stm32f3xx_hal.c stm32f3xx_hal_cortex.c stm32f3xx_hal_gpio.c
+SRCS      += stm32f4xx_hal_rcc.c stm32f4xx_hal_rcc_ex.c stm32f4xx_hal.c stm32f4xx_hal_cortex.c stm32f4xx_hal_gpio.c $(BSP_BASE).c
 
 # Directories
 OCD_DIR    = /usr/share/openocd/scripts
@@ -49,12 +51,12 @@ OCD_DIR    = /usr/share/openocd/scripts
 CUBE_DIR   = cube
 
 BSP_DIR    = $(CUBE_DIR)/Drivers/BSP/$(BOARD)
-HAL_DIR    = $(CUBE_DIR)/Drivers/STM32F3xx_HAL_Driver
+HAL_DIR    = $(CUBE_DIR)/Drivers/STM32F4xx_HAL_Driver
 CMSIS_DIR  = $(CUBE_DIR)/Drivers/CMSIS
 
-DEV_DIR    = $(CMSIS_DIR)/Device/ST/STM32F3xx
+DEV_DIR    = $(CMSIS_DIR)/Device/ST/STM32F4xx
 
-CUBE_URL   = http://www.st.com/st-web-ui/static/active/en/st_prod_software_internet/resource/technical/software/firmware/stm32cubef3.zip
+CUBE_URL   = http://www.st.com/st-web-ui/static/active/en/st_prod_software_internet/resource/technical/software/firmware/stm32cubef4.zip
 
 # that's it, no need to change anything below this line!
 
@@ -174,7 +176,7 @@ template: cube src
 	cp -ri $(CUBE_DIR)/Projects/$(BOARD)/$(EXAMPLE)/Src/* src
 	cp -ri $(CUBE_DIR)/Projects/$(BOARD)/$(EXAMPLE)/Inc/* src
 	cp -i $(DEV_DIR)/Source/Templates/gcc/startup_$(MCU_LC).s src
-	cp -i $(DEV_DIR)/Source/Templates/gcc/linker/$(MCU_UC)_FLASH.ld $(MCU_LC).ld
+	cp -i $(CUBE_DIR)/Projects/$(BOARD)/$(EXAMPLE)/TrueStudio/$(BOARD)/$(MCU_UC)_FLASH.ld $(MCU_LC).ld
 
 clean:
 	@echo "[RM]      $(TARGET).elf"; rm -f $(TARGET).elf


### PR DESCRIPTION
builds and tests OK on the STM32f4-discovery board (STM32F407VGT6) using the Launchpad arm GCC binaries.