### PR TITLE
bugfix: correct the path to the template linker file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ template: cube src
 	cp -ri $(CUBE_DIR)/Projects/$(BOARD)/$(EXAMPLE)/Src/* src
 	cp -ri $(CUBE_DIR)/Projects/$(BOARD)/$(EXAMPLE)/Inc/* src
 	cp -i $(DEV_DIR)/Source/Templates/gcc/startup_$(MCU_LC).s src
-	cp -i $(CUBE_DIR)/Projects/$(BOARD)/$(EXAMPLE)/TrueStudio/$(BOARD)/$(MCU_UC)_FLASH.ld $(MCU_LC).ld
+	cp -i $(CUBE_DIR)/Projects/$(BOARD)/$(EXAMPLE)/TrueSTUDIO/$(BOARD)/$(MCU_UC)_FLASH.ld $(MCU_LC).ld
 
 clean:
 	@echo "[RM]      $(TARGET).elf"; rm -f $(TARGET).elf


### PR DESCRIPTION
'make template' fails to copy the linker file since it is the wrong path. This will fix that.